### PR TITLE
Remove plugins that slow down vim.

### DIFF
--- a/custom_vimrc
+++ b/custom_vimrc
@@ -7,13 +7,8 @@ let g:matchup_matchpref = {
 
 " let g:matchup_hotfix_javascript = 'JsxHotfix'
 
-let g:nd_themes = [
-      \ ['06:00',  'PaperColor', 'light' ],
-      \ ['13:00',  'scheakur', 'light' ],
-      \ ['15:00',  'vim-monokai-tasty', '' ],
-      \ ['18:00',  'gruvbox', 'dark' ]
-      \ ]
-
+set background=light
+colorscheme gruvbox
 let g:tablineclosebutton=0
 let g:fzf_buffers_jump = 1
 let g:fzf_tags_command = 'ctags -R'

--- a/vim-files/plugins.vim
+++ b/vim-files/plugins.vim
@@ -60,7 +60,7 @@ Plug 'dhruvasagar/vim-table-mode'
 " Plugin to load the .editorconfig rules
 Plug 'editorconfig/editorconfig-vim'
 
-Plug 'nightsense/night-and-day'
+"Plug 'nightsense/night-and-day'
 
 Plug 'mbbill/undotree'
 


### PR DESCRIPTION
- Remove nightsense/night-and-day plugin because it was
using to much process time. and the vim screen was blinking(:sad).