### PR TITLE
Fix Fern size

### DIFF
--- a/vim-files/mappings.vim
+++ b/vim-files/mappings.vim
@@ -2,7 +2,7 @@
 " cSpell:disable
 
 " Fern: Plug 'lambdalisue/fern.vim'
-noremap <silent><C-p> :Fern . -drawer -reveal=% -toggle -width=30<CR><C-w>=
+nmap <silent><C-p> :Fern . -drawer -reveal=% -toggle -width=30<CR><Plug>(fern-action-zoom:reset)
 
 " Telescope:
 " Find files using Telescope command-line sugar.


### PR DESCRIPTION
Quick info
---

Fix the size of the Plugin Fern after the first time it is open.

Why are you changing that?
---

The Fern size was not setting the right size up after the first time it was open.

Screenshots
---

### Before 

![image](https://user-images.githubusercontent.com/4744667/127941633-138fdd75-73ad-4846-a686-a739be08d9c4.png)

### After

![image](https://user-images.githubusercontent.com/4744667/127941786-4759be37-c369-40a4-882b-0ba16bf911b7.png)