### PR TITLE
Add documentation for telescope live-grep

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,22 @@ git clone https://github.com/alexesba/nvim-config.git
 
 </h3>
 
+### Optional Installation
+
+```sh
+# If you want to use the "live grep" option for Telescope, then you need to make
+# sure that the "rg" command is installed in your system.
+
+# To check if you have rg execute the command bellow.
+
+which rg
+
+# If you don't have it you have to install it in order to be able to use the
+# "live grep" feature.
+
+brew install rg
+```
+
 -----
 
 ## Adding Customization
@@ -405,7 +421,7 @@ vim ~/.vimrc
 #    | PaperColor        | true             | true            |
 #    | codedark          | false            | false           |
 
-# There is a special configuration for the colorscheme ayu, for this color 
+# There is a special configuration for the colorscheme ayu, for this color
 # you will need to choose only one from the following list.
 
 #    | colorscheme | ayucolor |


### PR DESCRIPTION
The `telescope.nvim` has the live-grep feature used for searching strings in all the files of the directory using the telescope window.

This functionality needs the `rg` command. This change adds the documentation on the README mentioning it.