### PR TITLE
Small improvements

### DIFF
--- a/custom_vimrc
+++ b/custom_vimrc
@@ -13,4 +13,7 @@ autocmd! BufWritePre * call MkDir()
 " Vim syntax highlighting for ARB templates (ActiveAdmin) is not working
 autocmd! BufRead,BufNewFile *.arb setfiletype ruby
 
-set relativenumber
+autocmd! FileType javascriptreact
+      \ call tcomment#type#Define('javascriptreact',              {'commentstring_rx': '\%%(// %s\|{/* %s */}\)', 'commentstring': '{/* %s */}'})
+      \ call tcomment#type#Define('javascriptreact_block',        '{/* %s */}')
+      \ call tcomment#type#Define('javascriptreact_inline',       '{/* %s */}')

--- a/terminals/alacritty.yml
+++ b/terminals/alacritty.yml
@@ -1,5 +1,5 @@
 env:
-  TERM: xterm-256color-italic
+  TERM: xterm-256color
 
 window:
   dimensions:

--- a/vim-files/common.vim
+++ b/vim-files/common.vim
@@ -68,5 +68,5 @@ let g:jsx_ext_required = 0 "Allow jsx in normal js files
 
 " Enable italic fonts
 let g:enable_italic_font = 1
-
+let g:gruvbox_italic = 1
 autocmd BufWritePost * GitGutter

--- a/vim-files/mappings.vim
+++ b/vim-files/mappings.vim
@@ -2,7 +2,7 @@
 " cSpell:disable
 
 " Fern: Plug 'lambdalisue/fern.vim'
-nmap <silent><C-p> :Fern . -drawer -reveal=% -toggle -width=30<CR><Plug>(fern-action-zoom:reset)
+nmap <silent><C-p> :Fern . -drawer -reveal=% -toggle -width=30<CR><Plug>(fern-action-zoom:reset)<C-W>=
 
 " Telescope:
 " Find files using Telescope command-line sugar.

--- a/vim-files/mappings.vim
+++ b/vim-files/mappings.vim
@@ -142,13 +142,20 @@ inoremap <down> <nop>
 inoremap <left> <nop>
 inoremap <right> <nop>
 
+" Disable Arrow keys in Visual Mode
+vnoremap <Down> <Nop>
+vnoremap <Left> <Nop>
+vnoremap <Right> <Nop>
+vnoremap <Up> <Nop>
+"}}}
+
 noremap <Leader><Space>, :ll<CR>         " go to current error/warning
 noremap <Leader><Space>c :lclose<CR>     " close location window
 noremap <Leader><Space>n :lnext<CR>      " next error/warning
 noremap <Leader><Space>o :lopen<CR>      " open location window
 noremap <Leader><Space>p :lprev<CR>      " previous error/warning
 
-nnoremap <leader>cf :CopyFilePath<CR>
+nnoremap <leader>cf :CopyFilePath<CR>:echo "File path copied!"<CR>
 
 " Copy from cursor to the end of the line
 nnoremap Y y$

--- a/vim-files/plugins.vim
+++ b/vim-files/plugins.vim
@@ -36,9 +36,9 @@ Plug 'tpope/vim-surround'
 Plug 'ap/vim-css-color', { 'for': ['css','stylus','scss'] }
 Plug 'cakebaker/scss-syntax.vim', { 'for': 'scss' } " sass scss syntax support
 Plug 'mattn/emmet-vim', { 'for': ['jsx', 'js', 'html', 'haml'] }
-Plug 'mgechev/vim-jsx'
-Plug 'ntpeters/vim-better-whitespace'
 Plug 'pangloss/vim-javascript', { 'for': ['jsx', 'js'] }
+Plug 'mgechev/vim-jsx', { 'for': ['jsx', 'js'] }
+Plug 'ntpeters/vim-better-whitespace'
 Plug 'senderle/restoreview'
 Plug 'tpope/vim-cucumber', { 'for': 'feature' }
 Plug 'tpope/vim-haml', { 'for': 'haml' }


### PR DESCRIPTION
- Change default TERM for alacritty replace xterm-256color-italic with
  xterm-256color
- The change above is needed because the installer file is not creating
  the custom italic version for the xterm-256color.
- enable gruvbox italic fonts by default
- Fix a small issue with the Fern mapping, added <C-W>= to resize the
  windows and avoid a weird behavior when there are more than 2 panes
  open.
- Allow TComment plugin  to work with javascriptreact files.
- Added a specific configuration for the javascriptreact and allow
  comment lines for JSX files with js extension
