### PR TITLE
Feat/local config overlays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .netrwhist
 lazy-lock.json
 lua/config/leader.local.lua
+lua/config/options.local.lua
+lua/config/keymaps.local.lua

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ Uses **link** mode: symlinks `~/.config/nvim` → your clone. Good if you keep t
 2. Back up existing `~/.config/nvim` to `~/.config/nvim.bak.<timestamp>`
 3. **clone** or **link** as above
 4. Ask for your `<leader>` key when run interactively (default `,`; skipped if `leader.local.lua` already exists)
-5. Run `nvim --headless "+Lazy! sync"` to install plugins
-6. Open Neovim
+5. Seed `options.local.lua` and `keymaps.local.lua` from examples if missing (never overwrites existing files)
+6. Run `nvim --headless "+Lazy! sync"` to install plugins
+7. Open Neovim
 
 ```bash
 ./install.sh --help   # usage and environment variables
@@ -74,8 +75,11 @@ Uses **link** mode: symlinks `~/.config/nvim` → your clone. Good if you keep t
 | `INSTALL_MODE` | auto (`ready` / `link` / `clone`) | Force `clone` or `link` |
 | `MAPLEADER` | `,` | Leader key when install is non-interactive (`curl \| bash`) |
 | `FORCE_LEADER` | — | Set to `1` to choose leader again during install |
+| `FORCE_LOCAL` | — | Set to `1` to re-copy `options.local.lua` / `keymaps.local.lua` from examples |
 
 After install: `:Lazy`, `:Lazy sync`, `:LazyExtras`.
+
+**Clone without `install.sh`?** Defaults work out of the box (`<leader>` is `,`). Run `nvim --headless "+Lazy! sync" +qa` once, then copy any `*.local.lua.example` to `*.local.lua` to customize (those files are gitignored).
 
 ## What’s included
 
@@ -83,7 +87,7 @@ After install: `:Lazy`, `:Lazy sync`, `:LazyExtras`.
 
 - **LazyVim** — IDE-style defaults (LSP, formatting, linting, treesitter, which-key, etc.)
 - **lazy.nvim** — plugin manager
-- **Leader key** — `<leader>` (default: `,` comma). `install.sh` can prompt for your choice and writes `lua/config/leader.local.lua` (gitignored). Change later by editing that file or copying from `lua/config/leader.local.lua.example`
+- **Leader key** — `<leader>` (default: `,` comma). Override in `lua/config/leader.local.lua` (gitignored)
 
 ### LazyVim extras (`lazyvim.json`)
 
@@ -290,18 +294,105 @@ LazyVim’s own maps (LSP, windows, etc.) still apply — press `<leader>` and w
 ├── lua/
 │   ├── config/
 │   │   ├── lazy.lua      # lazy.nvim + LazyVim bootstrap
-│   │   ├── options.lua   # vim options, leader, UI prefs
-│   │   ├── keymaps.lua   # Custom keymaps
+│   │   ├── options.lua   # vim options + loads leader/options .local.lua
+│   │   ├── keymaps.lua   # Custom keymaps + loads keymaps.local.lua
+│   │   ├── leader.local.lua.example
+│   │   ├── options.local.lua.example
+│   │   ├── keymaps.local.lua.example
 │   │   ├── autocmds.lua  # Autocmds + user commands
 │   │   └── colorscheme.lua  # Persist/load theme helpers
 │   ├── plugins/          # Plugin specs (one file per concern)
-│   └── utils/            # Shared helpers (map, functions, etc.)
+│   └── utils/
+│       └── local.lua       # dofile loader for gitignored *.local.lua overlays
 └── README.md
 ```
 
 Add or override plugins by creating files under `lua/plugins/`; they are imported automatically from `lua/config/lazy.lua`.
 
 ## Customization
+
+### Personal settings (`.local.lua` overlays)
+
+Tracked defaults live in `lua/config/options.lua` and `lua/config/keymaps.lua`. Put **your** machine-specific changes in gitignored `*.local.lua` files so `git pull` never conflicts with your personal prefs.
+
+#### How it works
+
+`lua/utils/local.lua` provides a small loader used by the config:
+
+```lua
+require("utils.local").load("options")  -- dofile lua/config/options.local.lua if it exists
+```
+
+- Looks for `lua/config/<name>.local.lua` under your Neovim config directory (`stdpath("config")`).
+- Missing files are skipped silently (no error).
+- Syntax or runtime errors in a `.local.lua` file show a `vim.notify` warning; Neovim still starts with repo defaults.
+
+#### Files and load order
+
+| Gitignored file | Example template | When it loads | Typical contents |
+| --- | --- | --- | --- |
+| `leader.local.lua` | `leader.local.lua.example` | Early in `options.lua`, right after default `vim.g.mapleader` | `vim.g.mapleader`, `vim.g.maplocalleader` |
+| `options.local.lua` | `options.local.lua.example` | End of `options.lua`, after all repo `vim.opt` / `vim.g` | `vim.opt.*`, `vim.g.*`, plugin globals |
+| `keymaps.local.lua` | `keymaps.local.lua.example` | End of `keymaps.lua`, after repo keymaps | `map(...)` calls via `utils.map` |
+
+Leader loads **before** other `vim.g` settings in `options.lua` so your leader key is set early. Options and keymaps load **last** so your values override repo defaults.
+
+All three paths are listed in `.gitignore` — they stay on your machine only.
+
+#### Setup
+
+**With `install.sh`** (recommended on first install):
+
+1. Prompts for `<leader>` and writes `leader.local.lua` (skipped if the file already exists).
+2. Copies `options.local.lua.example` → `options.local.lua` and `keymaps.local.lua.example` → `keymaps.local.lua` only when those files are missing.
+
+**Manually** (clone without `install.sh`, or add overlays later):
+
+```bash
+cp lua/config/leader.local.lua.example lua/config/leader.local.lua   # optional; default leader is ,
+cp lua/config/options.local.lua.example lua/config/options.local.lua
+cp lua/config/keymaps.local.lua.example lua/config/keymaps.local.lua
+```
+
+Then edit the `.local.lua` files. Restart Neovim after changes (lazy.nvim does not fully hot-reload structural config).
+
+#### Examples
+
+`leader.local.lua`:
+
+```lua
+vim.g.mapleader = " "
+vim.g.maplocalleader = "\\"
+```
+
+`options.local.lua`:
+
+```lua
+vim.opt.relativenumber = false
+vim.opt.colorcolumn = "100"
+vim.opt.wrap = true
+```
+
+`keymaps.local.lua`:
+
+```lua
+local map = require("utils.map").map
+map("n", "<leader>x", "<cmd>echo 'my map'<cr>", { noremap = true, silent = true })
+```
+
+#### Forcing a reset
+
+`install.sh` **never overwrites** existing local files. To regenerate from examples:
+
+| Goal | Command |
+| --- | --- |
+| Re-prompt for leader | `FORCE_LEADER=1 ./install.sh` |
+| Re-copy options/keymaps templates | `FORCE_LOCAL=1 ./install.sh` |
+| Both | `FORCE_LEADER=1 FORCE_LOCAL=1 ./install.sh` |
+
+`FORCE_LOCAL` only affects `options.local.lua` and `keymaps.local.lua`; leader still uses `FORCE_LEADER`.
+
+### Other customization
 
 - **Change default colorscheme behavior** — `lua/plugins/colorscheme-persist.lua`, `lua/config/colorscheme.lua`
 - **Add plugins** — new `lua/plugins/<name>.lua` returning a lazy spec table

--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,7 @@ Environment:
   INSTALL_MODE        clone | link (same as the argument)
   MAPLEADER           Leader key (non-interactive installs; default: ,)
   FORCE_LEADER        Set to 1 to re-prompt even if leader.local.lua exists
+  FORCE_LOCAL         Set to 1 to re-copy options/keymaps .local.lua from examples
 EOF
 }
 
@@ -229,6 +230,31 @@ EOF
   info "Leader key saved to lua/config/leader.local.lua"
 }
 
+seed_local_from_example() {
+  local name="$1"
+  local root example target
+  root="$(config_root)"
+  example="$root/lua/config/${name}.local.lua.example"
+  target="$root/lua/config/${name}.local.lua"
+  mkdir -p "$(dirname "$target")"
+
+  if [[ -f "$target" && -z "${FORCE_LOCAL:-}" ]]; then
+    return
+  fi
+  if [[ ! -f "$example" ]]; then
+    return
+  fi
+
+  cp "$example" "$target"
+  info "Created lua/config/${name}.local.lua from example (gitignored; edit freely)"
+}
+
+configure_local_files() {
+  configure_leader
+  seed_local_from_example "options"
+  seed_local_from_example "keymaps"
+}
+
 sync_plugins() {
   info "Installing plugins (lazy.nvim sync)..."
   nvim --headless "+Lazy! sync" +qa
@@ -275,7 +301,7 @@ main() {
       ;;
   esac
 
-  configure_leader
+  configure_local_files
   sync_plugins
   open_nvim
 }

--- a/lua/config/keymaps.local.lua.example
+++ b/lua/config/keymaps.local.lua.example
@@ -1,0 +1,6 @@
+-- Personal keymaps (gitignored).
+-- Copy to keymaps.local.lua or run install.sh (creates this file if missing).
+-- Loaded after lua/config/keymaps.lua.
+
+-- local map = require("utils.map").map
+-- map("n", "<leader>x", "<cmd>echo 'my map'<cr>", { noremap = true, silent = true })

--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -1,6 +1,6 @@
 -- Keymaps are automatically loaded on the VeryLazy event
 -- Default keymaps that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/keymaps.lua
--- Add any additional keymaps here
+-- Personal overrides: lua/config/keymaps.local.lua (gitignored; see keymaps.local.lua.example)
 local map = require("utils.map").map
 
 map("n", "<Esc>", ":noh<CR>", { noremap = true, silent = true })
@@ -64,3 +64,5 @@ map("n", "<leader>rp", [[:%s/<C-r><C-w>/]])
 
 map("v", "J", [[:m '>+1<CR>gv=gv]])
 map("v", "K", [[:m '<-2<CR>gv=gv]])
+
+require("utils.local").load("keymaps")

--- a/lua/config/leader.local.lua.example
+++ b/lua/config/leader.local.lua.example
@@ -1,3 +1,4 @@
--- Copy to leader.local.lua (or let install.sh create it) to customize <leader>.
+-- Copy to leader.local.lua (gitignored) to customize <leader>.
+-- install.sh creates this file on first run; re-run with FORCE_LEADER=1 to change.
 -- Examples: ","  " "  "\\"
 vim.g.mapleader = ","

--- a/lua/config/options.local.lua.example
+++ b/lua/config/options.local.lua.example
@@ -1,0 +1,8 @@
+-- Personal vim options (gitignored).
+-- Copy to options.local.lua or run install.sh (creates this file if missing).
+-- Loaded after lua/config/options.lua — safe across git pull.
+
+-- vim.opt.relativenumber = false
+-- vim.opt.colorcolumn = "100"
+-- vim.opt.wrap = true
+-- vim.g.some_plugin_setting = true

--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -1,6 +1,7 @@
 -- Options are automatically loaded before lazy.nvim startup
 -- Default options that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/options.lua
--- Add any additional options here
+-- Personal overrides: lua/config/options.local.lua (gitignored; see options.local.lua.example)
+local load_local = require("utils.local").load
 local set = vim.opt
 vim.o.winborder = "rounded"
 set.number = true
@@ -36,14 +37,7 @@ set.diffopt:append({ "vertical" })
 vim.g.mapleader = ","
 vim.g.maplocalleader = "\\"
 
--- Optional override from install.sh or manual setup (gitignored)
-local leader_local = vim.fn.stdpath("config") .. "/lua/config/leader.local.lua"
-if vim.fn.filereadable(leader_local) == 1 then
-  local ok, err = pcall(dofile, leader_local)
-  if not ok then
-    vim.notify("Failed to load leader.local.lua: " .. err, vim.log.levels.WARN)
-  end
-end
+load_local("leader")
 
 vim.g.table_mode_corner = "+"
 vim.g.enable_italic_font = 1
@@ -73,3 +67,5 @@ set.wildignore:append({
 set.list = false
 set.updatetime = 500 -- ms before CursorHold fires (affects diagnostic float speed)
 -- set.cmdheight=0
+
+load_local("options")

--- a/lua/utils/local.lua
+++ b/lua/utils/local.lua
@@ -1,0 +1,15 @@
+local M = {}
+
+--- Load lua/config/<name>.local.lua if present (gitignored user overrides).
+function M.load(name)
+  local path = vim.fn.stdpath("config") .. "/lua/config/" .. name .. ".local.lua"
+  if vim.fn.filereadable(path) ~= 1 then
+    return
+  end
+  local ok, err = pcall(dofile, path)
+  if not ok then
+    vim.notify(("Failed to load %s.local.lua: %s"):format(name, err), vim.log.levels.WARN)
+  end
+end
+
+return M


### PR DESCRIPTION
Summary
Adds a gitignored .local.lua overlay pattern so personal Neovim settings never conflict with tracked repo defaults on git pull.

lua/utils/local.lua — shared loader that dofiles lua/config/<name>.local.lua when present; warns on errors, skips silently if missing
leader.local.lua, options.local.lua, keymaps.local.lua — gitignored; loaded from options.lua / keymaps.lua at the right point in startup (leader early, options/keymaps last so overrides win)
Example templates — *.local.lua.example for each overlay file
install.sh — seeds missing options.local.lua and keymaps.local.lua from examples; never overwrites existing files (FORCE_LOCAL=1 to reset templates; FORCE_LEADER=1 unchanged for leader)
README — documents load order, manual setup, examples, and env vars
No behavior change for users who don’t create any .local.lua files — defaults stay the same.

Test plan

 Fresh install (or FORCE_LOCAL=1 ./install.sh) creates options.local.lua and keymaps.local.lua from examples without touching existing files

 leader.local.lua with vim.g.mapleader = " " applies before other vim.g settings

 options.local.lua override (e.g. vim.opt.wrap = true) takes effect after repo defaults

 keymaps.local.lua custom map works after repo keymaps load

 Missing .local.lua files — Neovim starts with no errors

 Broken .local.lua syntax — vim.notify warning, Neovim still starts

 git status — *.local.lua files are not tracked